### PR TITLE
Tidy Django support version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 VERSION = "0.5.1"
 
 INSTALL_REQUIRES = [
-    "Django>=2.2.9,<=5.2",
+    "Django>=2.2.9,<6",
     "bleach==3.3.0",
     "bleach-allowlist>=1.0.3",
     "cryptography>=2.7",


### PR DESCRIPTION
`<=5.2` doesn't include e.g. 5.2.1. `<6` ensures that all patch versions are supported

#minor